### PR TITLE
Fix admin profile picture upload for members

### DIFF
--- a/src/app/api/admin/users/[userId]/route.js
+++ b/src/app/api/admin/users/[userId]/route.js
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
-import prisma from '@/lib/db'
+import { prisma } from '@/lib/db'
 import bcrypt from 'bcryptjs'
 
 // GET - Get specific user details (admin only)

--- a/src/app/api/admin/users/[userId]/upload-profile/route.js
+++ b/src/app/api/admin/users/[userId]/upload-profile/route.js
@@ -1,0 +1,102 @@
+import { NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { uploadProfilePicture } from '@/lib/supabase'
+
+export async function POST(request, { params }) {
+  try {
+    const session = await getServerSession(authOptions)
+    
+    if (!session || session.user.role !== 'ADMIN') {
+      return NextResponse.json(
+        { error: 'Unauthorized - Admin access required' },
+        { status: 401 }
+      )
+    }
+
+    const { userId } = params
+    const formData = await request.formData()
+    const file = formData.get('profilePic')
+
+    if (!file) {
+      return NextResponse.json(
+        { error: 'No file provided' },
+        { status: 400 }
+      )
+    }
+
+    // Check if target user exists
+    const targetUser = await prisma.user.findUnique({
+      where: { id: userId }
+    })
+
+    if (!targetUser) {
+      return NextResponse.json(
+        { error: 'User not found' },
+        { status: 404 }
+      )
+    }
+
+    // Validate file type
+    if (!file.type.startsWith('image/')) {
+      return NextResponse.json(
+        { error: 'File must be an image' },
+        { status: 400 }
+      )
+    }
+
+    // Validate file size (max 10MB)
+    if (file.size > 10 * 1024 * 1024) {
+      return NextResponse.json(
+        { error: 'File size must be less than 10MB' },
+        { status: 400 }
+      )
+    }
+
+    try {
+      // Convert file to buffer
+      const bytes = await file.arrayBuffer()
+      const buffer = Buffer.from(bytes)
+
+      // Upload and process image with Supabase (using target user's ID)
+      const uploadResult = await uploadProfilePicture(buffer, userId)
+
+      // Update target user's profile picture in database
+      const updatedUser = await prisma.user.update({
+        where: { id: userId },
+        data: { profilePic: uploadResult.url },
+        select: {
+          id: true,
+          email: true,
+          name: true,
+          bio: true,
+          profilePic: true,
+          role: true,
+          createdAt: true,
+          updatedAt: true
+        }
+      })
+
+      return NextResponse.json({
+        message: 'Profile picture uploaded successfully',
+        profilePic: uploadResult.url,
+        user: updatedUser
+      })
+
+    } catch (imageError) {
+      console.error('Error processing/uploading image:', imageError)
+      return NextResponse.json(
+        { error: 'Error processing image. Please try with a different image.' },
+        { status: 400 }
+      )
+    }
+
+  } catch (error) {
+    console.error('Error uploading profile picture:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/components/EditUserModal.js
+++ b/src/components/EditUserModal.js
@@ -80,15 +80,16 @@ export default function EditUserModal({ user, isOpen, onClose, onUserUpdated }) 
     if (!profilePicFile) return null
 
     const formData = new FormData()
-    formData.append('image', profilePicFile)
+    formData.append('profilePic', profilePicFile)
 
-    const response = await fetch('/api/profile/upload', {
+    const response = await fetch(`/api/admin/users/${user.id}/upload-profile`, {
       method: 'POST',
       body: formData
     })
 
     if (!response.ok) {
-      throw new Error('Failed to upload image')
+      const errorData = await response.json()
+      throw new Error(errorData.error || 'Failed to upload image')
     }
 
     const data = await response.json()


### PR DESCRIPTION
- Created new admin-specific endpoint /api/admin/users/[userId]/upload-profile for profile picture uploads
- Fixed EditUserModal to use the new admin endpoint instead of regular user upload endpoint
- Fixed import statement in admin users route (prisma named export instead of default export)
- Resolves 400 error when admins try to change profile pictures of members

The previous issue was that admins were using the regular /api/profile/upload endpoint which only allows users to update their own profile pictures. Now admins have a dedicated endpoint that properly handles uploads for any user by their userId.