### PR TITLE
fix: resolve SharedArrayBuffer error for FFmpeg.js video compression

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -17,13 +17,31 @@ const nextConfig = {
   // Headers configuration
   async headers() {
     return [
-      // Permissive headers for media to load properly
+      // Headers required for FFmpeg.js (SharedArrayBuffer support)
       {
         source: '/(.*)',
         headers: [
           {
+            key: 'Cross-Origin-Embedder-Policy',
+            value: 'require-corp'
+          },
+          {
+            key: 'Cross-Origin-Opener-Policy',
+            value: 'same-origin'
+          },
+          {
             key: 'Cross-Origin-Resource-Policy',
             value: 'cross-origin'
+          }
+        ]
+      },
+      // Special headers for static assets and scripts to work with COEP
+      {
+        source: '/_next/static/(.*)',
+        headers: [
+          {
+            key: 'Cross-Origin-Resource-Policy',
+            value: 'same-origin'
           }
         ]
       },
@@ -34,6 +52,10 @@ const nextConfig = {
           {
             key: 'Cache-Control',
             value: 'public, max-age=31536000, immutable' // 1 year cache
+          },
+          {
+            key: 'Cross-Origin-Resource-Policy',
+            value: 'cross-origin'
           }
         ]
       }
@@ -49,6 +71,12 @@ const nextConfig = {
         fs: false,
         path: false,
         crypto: false,
+      }
+      
+      // Ensure proper handling of SharedArrayBuffer for FFmpeg.js
+      config.experiments = {
+        ...config.experiments,
+        asyncWebAssembly: true,
       }
     }
     

--- a/src/components/PostVideoUpload.js
+++ b/src/components/PostVideoUpload.js
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useImperativeHandle, forwardRef } from 'react'
 import { Video, Upload, X, Check, Play, Pause } from 'lucide-react'
-import { compressVideo, getVideoMetadata, initializeFFmpeg } from '@/lib/videoCompression'
+import { compressVideo, getVideoMetadata, initializeFFmpeg, checkFFmpegSupport } from '@/lib/videoCompression'
 
 const PostVideoUpload = forwardRef(({ onVideoUpload, onError, disabled = false }, ref) => {
   const [isUploading, setIsUploading] = useState(false)
@@ -67,6 +67,12 @@ const PostVideoUpload = forwardRef(({ onVideoUpload, onError, disabled = false }
         size: file.size,
         type: file.type
       })
+
+      // Check browser compatibility first
+      const support = checkFFmpegSupport()
+      if (!support.isSupported) {
+        throw new Error(`Video compression is not supported in this browser. Missing: ${support.missingFeatures.join(', ')}. Please try using a different browser or ensure the site has proper security headers.`)
+      }
 
       // Initialize FFmpeg with progress tracking
       await initializeFFmpeg()


### PR DESCRIPTION
- Add Cross-Origin-Embedder-Policy: require-corp header to enable SharedArrayBuffer
- Add Cross-Origin-Opener-Policy: same-origin header for security isolation
- Configure webpack with asyncWebAssembly for proper WASM handling
- Add browser compatibility check (checkFFmpegSupport) before compression
- Improve error handling with user-friendly messages for unsupported browsers
- Add special CORP headers for static assets to work with COEP

This fixes the 'SharedArrayBuffer is not available' error in production.